### PR TITLE
white spaces corrected

### DIFF
--- a/1.10a-Header-guards/main.cpp
+++ b/1.10a-Header-guards/main.cpp
@@ -6,7 +6,7 @@
 
 int main()
 {
-
-std::cout << getSquareSides();
+    std::cout << getSquareSides();
+    
     return 0;
 }


### PR DESCRIPTION
 Each statement within braces should start one tab in from the opening brace of the function it belongs to.
